### PR TITLE
allow whitelist and authenticated-gets to be configured by user

### DIFF
--- a/lib/check-auth.js
+++ b/lib/check-auth.js
@@ -1,11 +1,15 @@
 module.exports = check
 
-var whitelist = ['/_session', '/-/user/org.couchdb.user:*']
+var default_whitelist = ['/_session', '/-/user/org.couchdb.user:*']
 
-function check(context, done) {
+function check(config, context, done) {
   var route = context.route.route
+  if (!config.auth.authenticated_gets && context.route.method === 'GET') {
+    return done();
+  }
 
-  if(context.route.method === 'GET' || whitelist.indexOf(route) !== -1) {
+  var whitelist = config.auth.whitelist || default_whitelist;
+  if(whitelist.indexOf(route) !== -1) {
     return done()
   }
 


### PR DESCRIPTION
This pr would have to be pulled with the authenticated-gets pr on the unpm repo.

This allows the end user a little more control of what is allowed on their private npm repo. It allows anon gets to be disabled, and them to alter the whitelist of routes. 
